### PR TITLE
Improving http resonse codes for edge cases in solicitation lookup

### DIFF
--- a/server/routes/solicitation.routes.js
+++ b/server/routes/solicitation.routes.js
@@ -34,14 +34,21 @@ module.exports = function (db) {
     get: function (req, res) {
       return Notice.findByPk(req.params.id)
         .then((notice) => {
+          if ( ! notice ) {  // no notice found with that ID
+            return res.status(404).send({})
+          }
           return predictionRoute.getPredictions({ solNum: notice.solicitation_number })
             .then(predictions => {
-              return res.status(200).send(predictions[0]) // we should only have one since they will all merge by solicitation number
+              // we should only have one 'prediction' since they will all merge by solicitation number
+              // but for consistency we should set the ID number to the one requested rather than to
+              // a pseudo-random choice
+              predictions[0].id = parseInt(req.params.id)
+              return res.status(200).send(predictions[0])
             })
         })
         .catch((e) => {
           logger.log('error', 'error in: solicitation get', { error:e, tag: 'solicitation get' })
-          return res.status(400).send('Error finding solicitation')
+          return res.status(500).send('Error finding solicitation')
         })
     },
 

--- a/server/tests/solicitation.routes.test.js
+++ b/server/tests/solicitation.routes.test.js
@@ -126,6 +126,34 @@ describe('solicitation tests', () => {
       })
   })
 
+  test('sending an non-existing ID to get solicitation', () => {
+    return db.sequelize.query('select id from notice order by solicitation_number desc limit 1')
+      .then((rows) => {
+        let id = rows[0][0].id + 9999
+        expect(id).toBeDefined()
+        return request(app)
+          .get('/api/solicitation/' + id)
+          .set('Authorization', `Bearer ${token}`)
+          .send({})
+          .then((res) => {
+            // noinspection JSUnresolvedVariable
+            return expect(res.statusCode).toBe(404)
+          })
+      })
+  })
+
+  test('sending a too large/invalid ID to get solicitation', () => {
+    let url = '/api/solicitation/' + Number.MAX_SAFE_INTEGER
+    return request(app)
+      .get(url)
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+      .then((res) => {
+        // noinspection JSUnresolvedVariable
+        return expect(res.statusCode).toBe(500)
+      })
+  })
+
   test('Test document count', () => {
     return db.sequelize.query('select solicitation_number , count(*) as c from attachment join notice n on attachment.notice_id = n.id group by solicitation_number order by count(*) desc;')
       .then((rows) => {


### PR DESCRIPTION
We were returning 400 when ID not found. Changed it to 404
Also added a 500 response code if we get an actual error.